### PR TITLE
make header-links configurable as a site setting

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 karl package Changelog
 ======================
 
+5.1.3 (unreleased)
+------------------
+
+- make header-links configurable through site settings
+
 5.1.2 (2015-08-04)
 ------------------
 

--- a/karl/models/site.py
+++ b/karl/models/site.py
@@ -447,10 +447,10 @@ class Site(Folder):
         safe_html=True,
         google_analytics_id='',
         navigation_list="\n".join([
-            "TAGS|/tagcloud.html",
-            "PEOPLE|/people",
-            "COMMUNITIES|/communities",
-            "FEEDS|/contentfeeds.html",
+            "Tags|/tagcloud.html",
+            "People|/people",
+            "Communities|/communities",
+            "Feeds|/contentfeeds.html",
         ]),
     )
     _repo = Uninitialized

--- a/karl/models/site.py
+++ b/karl/models/site.py
@@ -445,7 +445,13 @@ class Site(Folder):
         site_override_css="""/* provide custom override css here */""",
         reply_by_email_enabled=True,
         safe_html=True,
-        google_analytics_id=''
+        google_analytics_id='',
+        navigation_list="\n".join([
+            "TAGS|/tagcloud.html",
+            "PEOPLE|/people",
+            "COMMUNITIES|/communities",
+            "FEEDS|/contentfeeds.html",
+        ]),
     )
     _repo = Uninitialized
 

--- a/karl/views/admin.py
+++ b/karl/views/admin.py
@@ -1263,13 +1263,19 @@ class SiteSettingsFormController(BaseSiteFormController):
         'default_home_behavior',
         'site_override_css',
         'safe_html',
-        'google_analytics_id'
+        'google_analytics_id',
+        'navigation_list',
         )
     labels = {
         'title': 'Site title',
         'min_pw_length': 'Minimum Password Length',
         'default_home_behavior': 'Where user should be directed to by default',
-        'reply_by_email_enabled': 'Requires additional configuration'
+        'reply_by_email_enabled': 'Requires additional configuration',
+        'navigation_list':
+            'List of links to display on every page. Must be in the format '
+            '`Display Name|/url`. The "Display Name" is a human readable '
+            'name, the "/url" is a full, absolute, or relative URL. Both are '
+            'separated by a pipe ("|") character',
     }
     required = ['title', 'admin_email', 'system_list_subdomain', 'system_email_domain',
                 'site_url', 'min_pw_length', 'selectable_groups', 'date_format',
@@ -1305,6 +1311,7 @@ class SiteSettingsFormController(BaseSiteFormController):
         widgets['default_home_behavior'] = formish.widgets.SelectChoice(
             DEFAULT_HOME_BEHAVIOR_OPTIONS)
         widgets['site_override_css'] = formish.widgets.TextArea()
+        widgets['navigation_list'] = formish.widgets.TextArea()
         for bfield in self.bools:
             widgets[bfield] = formish.widgets.Checkbox()
         return widgets

--- a/karl/views/api.py
+++ b/karl/views/api.py
@@ -17,6 +17,7 @@
 
 import time
 import json
+from urlparse import urljoin, urlparse, urlunsplit
 
 from zope.component import getAdapter
 from zope.component import getMultiAdapter
@@ -534,3 +535,26 @@ class TemplateAPI(object):
         if resource:
             return resource.render(self.request)
         return '<!-- could not render resource %s -->' % name
+
+    def get_header_menu_items(self):
+        navlist = []
+        navitems = self.settings['navigation_list'].splitlines()
+        for item in navitems:
+            itemparts = item.split("|")
+            if len(itemparts) != 2:
+                continue
+            if itemparts[1].startswith("http://") or itemparts[1].startswith("https://"):
+                url = itemparts[1]
+            else:
+                # normalize the url
+                new = urlparse(urljoin(self.app_url, itemparts[1]).lower())
+                url = urlunsplit((
+                    new.scheme,
+                    new.netloc,
+                    new.path,
+                    new.query,
+                    '')
+                )
+            navlist.append(dict(display=itemparts[0], url=url))
+        navlist.reverse()
+        return navlist

--- a/karl/views/templates/snippets.pt
+++ b/karl/views/templates/snippets.pt
@@ -865,17 +865,8 @@ You are currently accessing KARL with Internet Explorer 8 or less. This is an ol
     </div>
 
     <ul id="header-menu" metal:define-macro="header-menu">
-        <li>
-          <a href="${api.app_url}/contentfeeds.html">Feeds</a>
-        </li>
-        <li id="header-communities">
-          <a href="${api.app_url}/communities">Communities</a>
-        </li>
-        <li id="header-people">
-          <a href="${api.people_url}">People</a>
-        </li>
-        <li id="header-tags">
-          <a href="${api.app_url}/tagcloud.html">Tags</a>
+        <li tal:repeat="item python:api.get_header_menu_items()">
+            <a href="${item['url']}">${item['display']}</a>
         </li>
     </ul>
 


### PR DESCRIPTION
It is handy to be able to reconfigure the header links by editing site settings.

The defaults are what the original hard-coded values were.