### PR TITLE
add option to add custom css class to header menu links

### DIFF
--- a/karl/views/admin.py
+++ b/karl/views/admin.py
@@ -1273,9 +1273,12 @@ class SiteSettingsFormController(BaseSiteFormController):
         'reply_by_email_enabled': 'Requires additional configuration',
         'navigation_list':
             'List of links to display on every page. Must be in the format '
-            '`Display Name|/url`. The "Display Name" is a human readable '
-            'name, the "/url" is a full, absolute, or relative URL. Both are '
-            'separated by a pipe ("|") character',
+            '`Display Name|/url|CSS Class List`. The "Display Name" is a human readable '
+            'name, the "/url" is a full, absolute, or relative URL. The "CSS '
+            'Class List" is a space separated list of CSS class names that '
+            'will be added to each header menu link. All three are '
+            'separated by a pipe ("|") character and the "CSS Class List" may '
+            'optionally be present.',
     }
     required = ['title', 'admin_email', 'system_list_subdomain', 'system_email_domain',
                 'site_url', 'min_pw_length', 'selectable_groups', 'date_format',

--- a/karl/views/api.py
+++ b/karl/views/api.py
@@ -541,7 +541,7 @@ class TemplateAPI(object):
         navitems = self.settings['navigation_list'].splitlines()
         for item in navitems:
             itemparts = item.split("|")
-            if len(itemparts) != 2:
+            if len(itemparts) != 2 and len(itemparts) != 3:
                 continue
             if itemparts[1].startswith("http://") or itemparts[1].startswith("https://"):
                 url = itemparts[1]
@@ -555,6 +555,9 @@ class TemplateAPI(object):
                     new.query,
                     '')
                 )
-            navlist.append(dict(display=itemparts[0], url=url))
+            extra_css = ''
+            if len(itemparts) == 3:
+                extra_css = itemparts[2]
+            navlist.append(dict(display=itemparts[0], url=url, extra_css=extra_css))
         navlist.reverse()
         return navlist

--- a/karl/views/templates/snippets.pt
+++ b/karl/views/templates/snippets.pt
@@ -866,7 +866,7 @@ You are currently accessing KARL with Internet Explorer 8 or less. This is an ol
 
     <ul id="header-menu" metal:define-macro="header-menu">
         <li tal:repeat="item python:api.get_header_menu_items()">
-            <a href="${item['url']}">${item['display']}</a>
+            <a href="${item['url']}" class="${item['extra_css']}">${item['display']}</a>
         </li>
     </ul>
 


### PR DESCRIPTION
kind of roles into the configurable header menu links -- adds the ability to specify custom css classes to each menu link.